### PR TITLE
scripts: check for token available + make exec

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,11 @@
 
 set -o errexit -o nounset
 
-# build
-JEKYLL_GITHUB_TOKEN=$GITHUB_TOKEN bundle exec jekyll build
+if [ -n "${GITHUB_TOKEN+1}" ] # is github token declared?
+then
+    echo "Use github metadata for build"
+    JEKYLL_GITHUB_TOKEN=$GITHUB_TOKEN bundle exec jekyll build
+else
+    echo "Do not use github metadata for build"
+    bundle exec jekyll build
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,9 +2,18 @@
 
 set -o errexit -o nounset
 
-# Requesting a page build
-# Blog: https://developer.github.com/changes/2016-07-06-github-pages-preview-api/
-# Docs: https://developer.github.com/v3/repos/pages/#request-a-page-build
-curl "https://api.github.com/repos/FriendsOfREDAXO/friendsofredaxo.github.io/pages/builds" \
-    -X POST -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.mister-fantastic-preview"
+if [ -n "${GITHUB_TOKEN+1}" ] # is github token declared?
+then
+
+    # Requesting a page build
+    # Blog: https://developer.github.com/changes/2016-07-06-github-pages-preview-api/
+    # Docs: https://developer.github.com/v3/repos/pages/#request-a-page-build
+    curl "https://api.github.com/repos/FriendsOfREDAXO/friendsofredaxo.github.io/pages/builds" \
+        -X POST -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github.mister-fantastic-preview"
+
+    echo "Requested page build! <3"
+
+else
+    echo "Did not request page build."
+fi


### PR DESCRIPTION
Aktuell fliegen uns die Scripts um die Ohren, wenn Travis versucht einen PR zu bauen. Das liegt daran, dass der Token aus Sicherheitsgründen nicht außerhalb des Repos zur Verfügung steht.

Die Prüfung verhindert nun zumindest, dass ein Fehler fliegt, wenn der Token nicht deklariert ist.