### PR TITLE
Tricks direkt verlinken

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ title: Friends Of REDAXO
 <div class="info">
     <p class="info__text">Friends Of REDAXO ist der Ort für gemeinsame REDAXO-Entwicklung!<br>
         <a class="info__calltoaction" href="{% link info.html %}">Informationen zum Projekt FriendsOfREDAXO</a><br>
-    <a class="info_calltoaction" href="https://github.com/FriendsOfREDAXO/tricks">Weiter zu den REDAXO-Tricks aus der Community</p>
+    <a class="info_calltoaction" href="https://friendsofredaxo.github.io/tricks/">Weiter zu den REDAXO-Tricks aus der Community</p>
     
 </div>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@ title: Friends Of REDAXO
 
 <div class="info">
     <p class="info__text">Friends Of REDAXO ist der Ort für gemeinsame REDAXO-Entwicklung!<br>
-        <a class="info__calltoaction" href="{% link info.html %}">Informationen zum Projekt</a></p>
+        <a class="info__calltoaction" href="{% link info.html %}">Informationen zum Projekt FriendsOfREDAXO</a><br>
+    <a class="info_calltoaction" href="https://github.com/FriendsOfREDAXO/tricks">Weiter zu den REDAXO-Tricks aus der Community</p>
+    
 </div>
 
 <ol class="highscore">


### PR DESCRIPTION
Ich klick mir da immer einen Wolf über das GitHub-Repo von Tricks (ja, ok, ein Klick, aber mich stört es). Ist es so besser? @schuer