### PR TITLE
config: extend the period in which projects are marked as new from 60 to 100 days

### DIFF
--- a/_includes/list-item.html
+++ b/_includes/list-item.html
@@ -2,7 +2,7 @@
 {% assign isarchived = repository.archived %}
 {% capture created %} {{ repository.created_at | date: '%s'}} {% endcapture %}
 {% capture transferred %} {{ site.data.projects[repository.name].transferred_at | date: '%s'}} {% endcapture %}
-{% capture duedate %} {{ 'now' | date: '%s' | minus: '5184000' }} {% endcapture %}
+{% capture duedate %} {{ 'now' | date: '%s' | minus: '8640000' }} {% endcapture %}
 
 {% if transferred and transferred > duedate %}
     {% assign isnew = true %}


### PR DESCRIPTION
60 Tage erschienen mir zu kurz für das »Neu«-Label an frischen Projekten, also probieren wir doch mal 100 Tage. 😄 