### PR TITLE
Sichtbarkeit neuer Projekte etwas verstärken

### DIFF
--- a/_includes/list-item.html
+++ b/_includes/list-item.html
@@ -10,7 +10,7 @@
     {% assign isnew = true %}
 {% endif %}
 
-<li class="highscore__item{% if isarchived %} highscore__item--archived{% endif %}">
+<li class="highscore__item {% if isarchived %}highscore__item--archived{% endif %} {% if isnew %}highscore__item--new{% endif %}">
     <div class="highscore__item-col highscore__item-col--1">
 
 {% assign leads = site.data.projects[repository.name].lead | split: "," | default: " " %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -147,6 +147,10 @@ a {
   background: rgba(255, 255, 255, 0.4);
 }
 
+.highscore__item--new {
+  background: rgba(255, 252, 217, 0.6);
+}
+
 .highscore__item-col {
   padding: 0 1em;
 


### PR DESCRIPTION
Verstärkt die Sichtbarkeit neuer Projekte ein kleines bisschen, indem die Hintergrundfarbe dezent gelb wird.

<img width="565" height="252" alt="Screenshot 2025-09-10 at 20 41 08" src="https://github.com/user-attachments/assets/5608b321-e115-4b34-b67b-0d19f7c48a2f" />
